### PR TITLE
Allow null value in params

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -198,9 +198,13 @@ class Server
             return $this->requestError($id);
         }
 
-        // The 'params' key is optional, but must be non-null when provided
+        // The 'params' key is optional, but must be null|array when provided
         if (array_key_exists('params', $request)) {
             $arguments = $request['params'];
+
+            if (is_null($arguments)) {
+                $arguments = array();
+            }
 
             if (!is_array($arguments)) {
                 return $this->requestError($id);

--- a/tests/Api.php
+++ b/tests/Api.php
@@ -35,6 +35,9 @@ class Api implements Evaluator
             case 'subtract':
                 return self::subtract($arguments);
 
+            case 'null params':
+                return self::nullParams($arguments);
+
             case 'implementation error':
                 return self::implementationError($arguments);
 
@@ -66,6 +69,11 @@ class Api implements Evaluator
         }
 
         return $a - $b;
+    }
+
+    private function nullParams($arguments)
+    {
+        return count($arguments);
     }
 
     private static function implementationError($arguments)

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -146,6 +146,15 @@ class ServerTest extends TestCase
         $this->compare($input, $output);
     }
 
+    public function testNullParams()
+    {
+        $input = '{"jsonrpc": "2.0", "method": "null params", "id": "1", "params": null}';
+
+        $output = '{"jsonrpc": "2.0", "id": "1", "result": 0}';
+
+        $this->compare($input, $output);
+    }
+
     public function testImplementationError()
     {
         $input = '{"jsonrpc": "2.0", "id": 1, "method": "implementation error"}';


### PR DESCRIPTION
This PR allows the use of null value in params key.

Some LSP clients can send requests with null as params value and it will be helpful to handle such requests. One example of this comes from language server protocol [specifications](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#shutdown).

I have added `is_null` check if params key exists to handle this.

Cheers.